### PR TITLE
Add label store implementation and example notebook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Change Log
 Added
 ~~~~~
 
+- RfAnnotationGroupLabelStore -- a class for storing labels (and fetching labels) from an annotation group associated with a Raster Foundry project layer `#11 <https://github.com/raster-foundry/raster-vision-plugin/pull/11>`__
 - RfAnnotationGroupLabelSource -- a class for getting labels from an annotation group associated with a Raster Foundry project layer `#10 <https://github.com/raster-foundry/raster-vision-plugin/pull/10>`__
 - RfLayerRasterSource -- a source for getting raster imagery from Raster Foundry scenes in a Raster Foundry project layer `#9 <https://github.com/raster-foundry/raster-vision-plugin/pull/9>`__
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports=true

--- a/notebooks/RfAnnotationGroupLabelStore.ipynb
+++ b/notebooks/RfAnnotationGroupLabelStore.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rf_raster_vision_plugin.label_source.rf_annotation_group_label_source import RfAnnotationGroupLabelSource\n",
+    "from rf_raster_vision_plugin.label_store.rf_annotation_group_label_store import RfAnnotationGroupLabelStore\n",
+    "import rf_raster_vision_plugin.raster_source.rf_layer_raster_source as rlrs\n",
+    "\n",
+    "from uuid import uuid4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "refresh_token = 'YOUR REFRESH TOKEN HERE'\n",
+    "\n",
+    "source = rlrs.RfLayerRasterSource(\n",
+    "    '71820687-526e-4203-8aab-3bf1acd5cc70', # This project is set to public\n",
+    "    '3cec2bbe-bb42-4df8-9478-bc8e57ab011e', # This is the project's default layer id\n",
+    "    str(uuid4()), # annotation group id -- not yet relevant\n",
+    "    refresh_token,\n",
+    "    [1, 2, 3],\n",
+    "    3\n",
+    ")\n",
+    "\n",
+    "label_source = RfAnnotationGroupLabelSource(\n",
+    "    '59388cf6-5105-467c-a8f3-f098055be8f0', # annotation group id\n",
+    "    '71820687-526e-4203-8aab-3bf1acd5cc70', # project id\n",
+    "    '3cec2bbe-bb42-4df8-9478-bc8e57ab011e', # project layer id\n",
+    "    refresh_token, # refresh token\n",
+    "    source.get_crs_transformer()\n",
+    ")\n",
+    "\n",
+    "label_store = RfAnnotationGroupLabelStore(\n",
+    "    'f4ce0d21-85a0-4239-b684-a8545837b106', # annotation group id -- named 'predictions'\n",
+    "    '71820687-526e-4203-8aab-3bf1acd5cc70', # project id\n",
+    "    '3cec2bbe-bb42-4df8-9478-bc8e57ab011e', # project layer id\n",
+    "    refresh_token, # refresh token\n",
+    "    source.get_crs_transformer(),\n",
+    "    {'870e82d4-0063-44f4-8a14-950266b23619': 1} # from the label source example\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The label that starts in the ground truth data\n",
+    "# It's of the right type, so we'll use these labels to prove that\n",
+    "# the LabelStore also works\n",
+    "\n",
+    "label_source.get_labels().boxlist.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check the starting labels\n",
+    "\n",
+    "starting = label_store.get_labels()\n",
+    "starting.boxlist.num_boxes()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the labels from the label source to the label store\n",
+    "\n",
+    "label_store.save(label_source.get_labels())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the labels in the store after we've saved to prove that they're different\n",
+    "\n",
+    "re_fetched = label_store.get_labels()\n",
+    "re_fetched.boxlist.data"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+rastervision >= 0.9.0
 requests >= 2.22.0
 mypy >= 0.701

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
+        'rastervision >= 0.9.0',
         'requests >= 2.22.0',
         'mypy >= 0.701'
     ],

--- a/src/rf_raster_vision_plugin/http/converters.py
+++ b/src/rf_raster_vision_plugin/http/converters.py
@@ -1,0 +1,48 @@
+from rastervision.core import Box
+from rastervision.data.crs_transformer import CRSTransformer
+from rastervision.data.crs_transformer.rasterio_crs_transformer import (
+    RasterioCRSTransformer,
+)
+from rastervision.data.label.object_detection_labels import ObjectDetectionLabels
+
+from mypy.types import List
+from uuid import UUID
+
+
+def annotation_features_from_labels(
+    labels: ObjectDetectionLabels,
+    crs_transformer: CRSTransformer,
+    annotation_group: UUID,
+    inverted_class_map: dict,
+) -> List[dict]:
+    # Build a new RasterioCRSTransformer, which defaults to 4326
+    lat_lng_xform = RasterioCRSTransformer(
+        crs_transformer.transform, crs_transformer.image_proj.srs
+    )
+    box_list = labels.boxlist
+    boxes = [
+        Box.from_npbox(npbox)
+        .reproject(lat_lng_xform.pixel_to_map)
+        .geojson_coordinates()
+        for npbox in box_list.data["boxes"]
+    ]
+
+    return [
+        {
+            "geometry": {"type": "Polygon", "coordinates": [box]},
+            "properties": {
+                "owner": None,
+                "label": inverted_class_map[class_id],
+                "description": None,
+                "machineGenerated": True,
+                "confidence": score,
+                "quality": None,
+                "annotationGroup": annotation_group,
+                "labeledBy": None,
+                "verifiedBy": None,
+            },
+        }
+        for box, class_id, score in zip(
+            boxes, labels.boxlist.data["classes"], labels.boxlist.data["scores"]
+        )
+    ]

--- a/src/rf_raster_vision_plugin/http/raster_foundry.py
+++ b/src/rf_raster_vision_plugin/http/raster_foundry.py
@@ -1,7 +1,9 @@
 import requests
 
-from mypy.types import Optional
+from mypy.types import List, Optional
 from uuid import UUID
+
+from .converters import annotation_features_from_labels
 
 
 def get_api_token(refresh_token: str, api_host: str) -> str:
@@ -51,6 +53,26 @@ def get_project(jwt: str, api_host: str, project_id: UUID) -> dict:
             rf_api_host=api_host, project_id=project_id
         ),
         headers={"Authorization": jwt},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def post_labels(
+    jwt: str,
+    api_host: str,
+    project_id: UUID,
+    project_layer_id: UUID,
+    labels: List[dict],
+) -> dict:
+    resp = requests.post(
+        "https://{rf_api_host}/api/projects/{project_id}/layers/{project_layer_id}/annotations".format(
+            rf_api_host=api_host,
+            project_id=project_id,
+            project_layer_id=project_layer_id,
+        ),
+        headers={"Authorization": jwt},
+        json={"features": labels},
     )
     resp.raise_for_status()
     return resp.json()

--- a/src/rf_raster_vision_plugin/http/raster_foundry.py
+++ b/src/rf_raster_vision_plugin/http/raster_foundry.py
@@ -34,12 +34,12 @@ def get_labels(
         resp.raise_for_status()
         return resp.json()
 
-    base_params = {"annotationGroup": annotation_group_id, "pageSize": 100, "page": 0}
+    params = {"annotationGroup": annotation_group_id, "pageSize": 100, "page": 0}
 
-    geojson = make_request(base_params)
+    geojson = make_request(params)
 
     while geojson["hasNext"]:
-        params["page"] += 1
+        params["page"] = params["page"] + 1  # type: ignore
         resp = make_request(params)
         geojson["hasNext"] = resp["hasNext"]
         geojson["features"] += resp["features"]

--- a/src/rf_raster_vision_plugin/http/vision.py
+++ b/src/rf_raster_vision_plugin/http/vision.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 class Experiment(object):
     # TODO: fill in from experiment create non-optional members
-    def __init__(self) -> Experiment:
+    def __init__(self):
         pass
 
 

--- a/src/rf_raster_vision_plugin/label_source/rf_annotation_group_label_source.py
+++ b/src/rf_raster_vision_plugin/label_source/rf_annotation_group_label_source.py
@@ -42,7 +42,7 @@ class RfAnnotationGroupLabelSource(LabelSource):
             rf_api_host (str): The url host name to use for communicating with Raster Foundry
         """
 
-        self._token = None
+        self._token = ""
         self._labels = None  # dict
         self.annotation_group = annotation_group
         self.project_id = project_id

--- a/src/rf_raster_vision_plugin/label_source/rf_annotation_group_label_source.py
+++ b/src/rf_raster_vision_plugin/label_source/rf_annotation_group_label_source.py
@@ -31,7 +31,6 @@ class RfAnnotationGroupLabelSource(LabelSource):
         refresh_token: str,
         crs_transformer: CRSTransformer,
         rf_api_host: str = "app.staging.rasterfoundry.com",
-        rf_tile_host: str = "tiles.staging.rasterfoundry.com",
     ):
         """Construct a new LabelSource
 
@@ -41,7 +40,6 @@ class RfAnnotationGroupLabelSource(LabelSource):
             project_layer_id (UUID): A Raster Foundry project layer id in this project
             refresh_token (str): A Raster Foundry refresh token to use to obtain an auth token
             rf_api_host (str): The url host name to use for communicating with Raster Foundry
-            rf_tile_host (str): The url host name to use for communicating with the Raster Foundry tile server
         """
 
         self._token = None
@@ -49,12 +47,10 @@ class RfAnnotationGroupLabelSource(LabelSource):
         self.annotation_group = annotation_group
         self.project_id = project_id
         self.project_layer_id = project_layer_id
-        self.refresh_token = refresh_token
         self.crs_transformer = crs_transformer
         self.rf_api_host = rf_api_host
-        self.rf_tile_host = rf_tile_host
 
-        self._get_api_token()
+        self._get_api_token(refresh_token)
         self._set_labels()
         self._set_class_map()
         self._set_rv_labels()
@@ -70,8 +66,8 @@ class RfAnnotationGroupLabelSource(LabelSource):
             self.crs_transformer,
         )
 
-    def _get_api_token(self):
-        self._token = rf.get_api_token(self.refresh_token, self.rf_api_host)
+    def _get_api_token(self, refresh_token: str):
+        self._token = rf.get_api_token(refresh_token, self.rf_api_host)
 
     def _set_labels(self):
         self._raw_labels = rf.get_labels(

--- a/src/rf_raster_vision_plugin/label_store/rf_annotation_group_label_store.py
+++ b/src/rf_raster_vision_plugin/label_store/rf_annotation_group_label_store.py
@@ -1,17 +1,62 @@
-import rastervision as rv
+from rastervision.data.crs_transformer import CRSTransformer
+from rastervision.data.label.object_detection_labels import ObjectDetectionLabels
+from rastervision.data.label_store import LabelStore
 
-from mypy import typing, Dict
+from mypy.types import Dict
 from uuid import UUID
 
+from ..http import raster_foundry as rf
+from ..http.converters import annotation_features_from_labels
+from ..label_source.rf_annotation_group_label_source import RfAnnotationGroupLabelSource
 
-class RfAnnotationGroupLabelStore(rv.LabelStore):
+
+class RfAnnotationGroupLabelStore(LabelStore):
     def __init__(
         self,
-        out_annotation_group: UUID,
+        annotation_group: UUID,
         project_id: UUID,
         project_layer_id: UUID,
-        uri: str,
-        crs_transformer: rv.CRSTransformer,
+        refresh_token: str,
+        crs_transformer: CRSTransformer,
         class_map: Dict[int, str],
-    ) -> RfAnnotationGroupLabelStore:
-        pass
+        rf_api_host: str = "app.staging.rasterfoundry.com",
+    ):
+        self.annotation_group = annotation_group
+        self.project_id = project_id
+        self.project_layer_id = project_layer_id
+        self.crs_transformer = crs_transformer
+        self.class_map = class_map
+        self.rf_api_host = rf_api_host
+        self._refresh_token = refresh_token
+
+        self._get_api_token(refresh_token)
+
+    def _get_api_token(self, refresh_token: str):
+        self._token = rf.get_api_token(refresh_token, self.rf_api_host)
+
+    def get_labels(self) -> ObjectDetectionLabels:
+        return RfAnnotationGroupLabelSource(
+            self.annotation_group,
+            self.project_id,
+            self.project_layer_id,
+            self._refresh_token,
+            self.crs_transformer,
+            self.rf_api_host,
+        ).get_labels()
+
+    def empty_labels(self) -> ObjectDetectionLabels:
+        return ObjectDetectionLabels.make_empty()
+
+    def save(self, labels: ObjectDetectionLabels) -> None:
+        rf.post_labels(
+            self._token,
+            self.rf_api_host,
+            self.project_id,
+            self.project_layer_id,
+            annotation_features_from_labels(
+                labels,
+                self.crs_transformer,
+                self.annotation_group,
+                {v: k for k, v in self.class_map.items()},
+            ),
+        )

--- a/src/rf_raster_vision_plugin/raster_source/rf_layer_raster_source.py
+++ b/src/rf_raster_vision_plugin/raster_source/rf_layer_raster_source.py
@@ -50,8 +50,7 @@ class RfLayerRasterSource(rv.data.RasterSource):
         self.project_layer_id = project_layer_id
         self.rf_api_host = rf_api_host
         self.rf_tile_host = rf_tile_host
-        self.refresh_token = refresh_token
-        self._get_api_token()
+        self._get_api_token(refresh_token)
 
         self.rf_scenes = self.get_rf_scenes()
         self._rasterio_source = RasterioSource(
@@ -66,9 +65,9 @@ class RfLayerRasterSource(rv.data.RasterSource):
         )
         self._rasterio_source._activate()
 
-    def _get_api_token(self):
+    def _get_api_token(self, refresh_token):
         """Use the refresh token on this raster source to obtain a bearer token"""
-        self._token = get_api_token(self.refresh_token, self.rf_api_host)
+        self._token = get_api_token(refresh_token, self.rf_api_host)
 
     def get_rf_scenes(self):
         """Fetch all Raster Foundry scene metadata for this project layer"""


### PR DESCRIPTION
Overview
-----

This PR implements a label store that communicates with an annotation group in the Raster Foundry API.

Notes
-----

It's my assumption that `ObjectDetectionLabels` will be produced by the object detection task in RF, and that if we can post them successfully, we don't need to worry about proving that we can post object detection labels from any actual experiment results to prove that this works. This assumption should be verified. 

Testing
-----

- run the example notebook after filling in your refresh token
- confirm you get a new label that looks like the label that you started with

Closes #4 